### PR TITLE
Enforce typecheck in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint: install-dev
 	$(PYTHON) -m flake8 --max-line-length=88 --extend-ignore=E203,W503,E501,F401 ap_move_light_to_data tests
 
 typecheck: install-dev
-	$(PYTHON) -m mypy ap_move_light_to_data || true
+	$(PYTHON) -m mypy ap_move_light_to_data
 
 # Testing (install deps first, then run tests)
 test: install-dev


### PR DESCRIPTION
- Remove || true from typecheck target to enforce type checking

Assisted-by: Claude Code (Claude Sonnet 4.5)