### PR TITLE
Standardize dry-run flag to use single word format

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ python -m ap_move_light_to_data <source_dir> <dest_dir> [options]
 ### Options
 
 - `-d, --debug`: Enable debug output
-- `-n, --dry-run`: Show what would be done without actually moving files
+- `-n, --dryrun`: Show what would be done without actually moving files
 
 ### Example
 
@@ -53,7 +53,7 @@ python -m ap_move_light_to_data \
 python -m ap_move_light_to_data \
     "10_Blink" \
     "20_Data" \
-    --dry-run
+    --dryrun
 ```
 
 ## Calibration Requirements

--- a/ap_move_light_to_data/move_lights_to_data.py
+++ b/ap_move_light_to_data/move_lights_to_data.py
@@ -426,7 +426,7 @@ def main() -> int:
     )
 
     parser.add_argument(
-        "--dry-run",
+        "--dryrun",
         "-n",
         action="store_true",
         help="Show what would be done without actually moving files",
@@ -486,14 +486,14 @@ def main() -> int:
     print(f"Source directory: {args.source_dir}")
     print(f"Destination directory: {args.dest_dir}")
 
-    if args.dry_run:
+    if args.dryrun:
         print("\n*** DRY RUN - No files will be moved ***\n")
 
     results = process_light_directories(
         args.source_dir,
         args.dest_dir,
         args.debug,
-        args.dry_run,
+        args.dryrun,
         args.quiet,
     )
 


### PR DESCRIPTION
## Summary
Changed the `--dry-run` command-line flag to `--dryrun` to use a single-word format instead of hyphenated format. This includes updates to the argument parser, all references in the code, and documentation.

## Changes
- Updated argument parser to use `--dryrun` instead of `--dry-run`
- Updated all code references from `args.dry_run` to `args.dryrun` to match the new flag name
- Updated README.md documentation and examples to reflect the new flag format
- Short flag `-n` remains unchanged

## Details
This change standardizes the flag naming convention by removing the hyphen from the long-form flag. The argument parser automatically converts the flag name to the corresponding attribute name, so changing `--dryrun` ensures the attribute is accessed as `args.dryrun` rather than `args.dry_run`.

https://claude.ai/code/session_01GAgUnV1hzc6qx8yYbsd2xr