### PR TITLE
Add CRITICAL comments and tests to protect output order

### DIFF
--- a/ap_move_light_to_data/move_lights_to_data.py
+++ b/ap_move_light_to_data/move_lights_to_data.py
@@ -469,6 +469,15 @@ def print_summary(results: dict) -> None:
         f"{plural(results['date_count'], 'date')}, "
         f"{plural(results['filter_count'], 'filter')})"
     )
+
+    # CRITICAL: Output order MUST be: Biases, Darks, Flats
+    # CRITICAL: Bias MUST ALWAYS be shown (even if 0 of 0)
+    # This order has regressed multiple times - DO NOT CHANGE without updating tests
+    # See test_print_summary_output_order() in tests/test_move_lights_to_data.py
+    print(
+        f"Biases: {dir_count - results['skipped_no_bias']} of {dir_count} | "
+        f"{status_indicator(dir_count - results['skipped_no_bias'], dir_count)}"
+    )
     print(
         f"Darks:  {dir_count - results['skipped_no_darks']} of {dir_count} | "
         f"{status_indicator(dir_count - results['skipped_no_darks'], dir_count)}"
@@ -477,11 +486,6 @@ def print_summary(results: dict) -> None:
         f"Flats:  {dir_count - results['skipped_no_flats']} of {dir_count} | "
         f"{status_indicator(dir_count - results['skipped_no_flats'], dir_count)}"
     )
-    if results["skipped_no_bias"] > 0:
-        print(
-            f"Biases: {dir_count - results['skipped_no_bias']} of {dir_count} | "
-            f"{status_indicator(dir_count - results['skipped_no_bias'], dir_count)}"
-        )
     if results["errors"] > 0:
         print(f"Errors: {results['errors']}")
     print(f"{'='*70}\n")


### PR DESCRIPTION
- Reorder summary output to always show Biases first, then Darks, then Flats
- Add CRITICAL comments documenting required output order has regressed multiple times
- Add CRITICAL comment that bias MUST ALWAYS be shown even when 0 of 0
- Add 4 unit tests to enforce output order and prevent regression
- Document that tests must be updated if order changes

Assisted-by: Claude Code (Claude Sonnet 4.5)