### PR TITLE
Replace --allow-bias with --scale-dark flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage](https://github.com/jewzaam/ap-move-light-to-data/workflows/Coverage%20Check/badge.svg)](https://github.com/jewzaam/ap-move-light-to-data/actions/workflows/coverage.yml)
 [![Lint](https://github.com/jewzaam/ap-move-light-to-data/workflows/Lint/badge.svg)](https://github.com/jewzaam/ap-move-light-to-data/actions/workflows/lint.yml)
 [![Format](https://github.com/jewzaam/ap-move-light-to-data/workflows/Format%20Check/badge.svg)](https://github.com/jewzaam/ap-move-light-to-data/actions/workflows/format.yml)
+[![Type Check](https://github.com/jewzaam/ap-move-light-to-data/workflows/Type%20Check/badge.svg)](https://github.com/jewzaam/ap-move-light-to-data/actions/workflows/typecheck.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
@@ -55,7 +56,7 @@ python -m ap_move_light_to_data <source_dir> <dest_dir> [options]
 | `--debug`, `-d` | Enable debug output |
 | `--dryrun`, `-n` | Show what would be done without moving files |
 | `--quiet`, `-q` | Suppress progress output |
-| `--allow-bias` | Allow shorter darks with bias frames |
+| `--scale-dark` | Scale dark frames using bias compensation (allows shorter exposures). Default: exact exposure match only |
 | `--path-pattern REGEX` | Filter directories by regex pattern |
 
 ### Examples
@@ -70,8 +71,8 @@ python -m ap_move_light_to_data 10_Blink 20_Data --dryrun
 # Process only accept directories (skip rejected)
 python -m ap_move_light_to_data 10_Blink 20_Data --path-pattern ".*accept.*"
 
-# Allow shorter darks with bias frames
-python -m ap_move_light_to_data 10_Blink 20_Data --allow-bias
+# Enable bias-compensated dark scaling (allows shorter dark exposures)
+python -m ap_move_light_to_data 10_Blink 20_Data --scale-dark
 ```
 
 ## How It Works
@@ -81,9 +82,9 @@ The tool recursively evaluates directory trees and moves them atomically when:
 2. All calibration files are self-contained within the tree (not in parent directories)
 
 **Calibration matching criteria:**
-- **Darks**: Camera, set temperature, gain, offset, readout mode, exposure (unless `--allow-bias`)
+- **Darks**: Camera, set temperature, gain, offset, readout mode, exposure (unless `--scale-dark`)
 - **Flats**: Camera, set temperature, gain, offset, readout mode, filter
-- **Bias**: Only required with `--allow-bias` when dark exposure doesn't match light exposure
+- **Bias**: Only required with `--scale-dark` when dark exposure doesn't match light exposure
 
 **Recursive evaluation:**
 - Complete TARGET directory → moves entire TARGET atomically

--- a/ap_move_light_to_data/matching.py
+++ b/ap_move_light_to_data/matching.py
@@ -88,7 +88,7 @@ def check_calibration_for_light(
     light_metadata: Dict[str, Any],
     search_dirs: List[str],
     metadata_cache: Dict[str, Dict[str, Any]],
-    allow_bias: bool,
+    scale_darks: bool,
     debug: bool,
     quiet: bool,
 ) -> Dict[str, Any]:
@@ -99,7 +99,7 @@ def check_calibration_for_light(
         light_metadata: Light frame metadata dict
         search_dirs: Directories to search for calibration (ordered by priority)
         metadata_cache: Pre-loaded metadata dict to search from
-        allow_bias: Allow shorter darks with bias frames
+        scale_darks: Allow shorter darks with bias frames
         debug: Enable debug output
         quiet: Suppress progress output
 
@@ -156,7 +156,7 @@ def check_calibration_for_light(
                 metadata_dict=dir_cache,
                 reference=light_metadata,
                 match_fields=config.DARK_MATCH_KEYWORDS,
-                allow_shorter_exposure=allow_bias,
+                allow_shorter_exposure=scale_darks,
             )
             if dir_cache
             else []
@@ -174,7 +174,7 @@ def check_calibration_for_light(
                 float(d.get(config.NORMALIZED_HEADER_EXPOSURESECONDS, -1)) == light_exp
                 for d in darks
             )
-            result["needs_bias"] = allow_bias and not exact_match
+            result["needs_bias"] = scale_darks and not exact_match
             break
 
     # Search for flats

--- a/tests/test_integration_move_lights_to_data.py
+++ b/tests/test_integration_move_lights_to_data.py
@@ -62,7 +62,7 @@ class TestIntegrationCompleteScenarios:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # Entire DATE1 should move as one unit
@@ -109,7 +109,7 @@ class TestIntegrationCompleteScenarios:
         )
 
         def mock_check_calibration(
-            light_metadata, search_dirs, allow_bias, debug, quiet, metadata_cache=None
+            light_metadata, search_dirs, scale_darks, debug, quiet, metadata_cache=None
         ):
             # Complete for DATE1, incomplete for DATE2
             if search_dirs[0] == light_dir1:
@@ -142,7 +142,7 @@ class TestIntegrationCompleteScenarios:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # Only DATE1 should move
@@ -196,7 +196,7 @@ class TestIntegrationCompleteScenarios:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # FILTER_R should move independently
@@ -236,7 +236,7 @@ class TestIntegrationCompleteScenarios:
         )
 
         def mock_check_calibration(
-            light_metadata, search_dirs, allow_bias, debug, quiet, metadata_cache=None
+            light_metadata, search_dirs, scale_darks, debug, quiet, metadata_cache=None
         ):
             if search_dirs[0] == light_r:
                 return {
@@ -268,7 +268,7 @@ class TestIntegrationCompleteScenarios:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # DATE1 is excluded because it contains incomplete light_b
@@ -323,7 +323,7 @@ class TestIntegrationCompleteScenarios:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # Only accept should be processed and moved
@@ -367,7 +367,7 @@ class TestIntegrationCompleteScenarios:
         )
 
         def mock_check_calibration(
-            light_metadata, search_dirs, allow_bias, debug, quiet, metadata_cache=None
+            light_metadata, search_dirs, scale_darks, debug, quiet, metadata_cache=None
         ):
             if search_dirs[0] == light_dir1:
                 return {
@@ -399,7 +399,7 @@ class TestIntegrationCompleteScenarios:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # Both should move: DATE1 independently, entire TARGET for DATE2

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -93,7 +93,7 @@ class TestCheckCalibrationForLight:
             light_metadata,
             search_dirs,
             metadata_cache={},
-            allow_bias=False,
+            scale_darks=False,
             debug=False,
             quiet=True,
         )
@@ -129,7 +129,7 @@ class TestCheckCalibrationForLight:
             light_metadata,
             search_dirs,
             metadata_cache={},
-            allow_bias=False,
+            scale_darks=False,
             debug=False,
             quiet=True,
         )

--- a/tests/test_move_lights_to_data.py
+++ b/tests/test_move_lights_to_data.py
@@ -63,7 +63,7 @@ class TestIsTreeCompleteAndSelfContained:
         result = move_lights_to_data.is_group_complete_and_self_contained(
             group_path=str(tree),
             source_dir=str(tmp_path),
-            allow_bias=False,
+            scale_darks=False,
             debug=False,
             quiet=True,
             metadata_cache={},
@@ -108,7 +108,7 @@ class TestIsTreeCompleteAndSelfContained:
         )
 
         result = move_lights_to_data.is_group_complete_and_self_contained(
-            str(tree), str(tmp_path), allow_bias=False, debug=False, quiet=True
+            str(tree), str(tmp_path), scale_darks=False, debug=False, quiet=True
         )
 
         assert result["is_complete"] is True
@@ -144,7 +144,7 @@ class TestIsTreeCompleteAndSelfContained:
         )
 
         result = move_lights_to_data.is_group_complete_and_self_contained(
-            str(tree), str(tmp_path), allow_bias=False, debug=False, quiet=True
+            str(tree), str(tmp_path), scale_darks=False, debug=False, quiet=True
         )
 
         assert result["is_complete"] is True
@@ -177,7 +177,7 @@ class TestIsTreeCompleteAndSelfContained:
         )
 
         result = move_lights_to_data.is_group_complete_and_self_contained(
-            str(tree), str(tmp_path), allow_bias=False, debug=False, quiet=True
+            str(tree), str(tmp_path), scale_darks=False, debug=False, quiet=True
         )
 
         assert result["is_complete"] is False
@@ -532,7 +532,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         assert result["moved"] == 0
@@ -585,7 +585,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=True,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         assert result["moved"] == 1
@@ -647,7 +647,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=True,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # CRITICAL: Source files must still exist
@@ -712,7 +712,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         assert result["moved"] == 1
@@ -777,7 +777,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=True,
+            scale_darks=True,
         )
 
         assert result["skipped_no_darks"] == 1
@@ -850,7 +850,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         assert result["moved"] == 3
@@ -908,7 +908,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         assert result["moved"] == 1
@@ -979,7 +979,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # Copy failed for one file, so deletion should be skipped entirely
@@ -1035,7 +1035,7 @@ class TestProcessLightDirectories:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         assert result["moved"] == 0
@@ -1095,7 +1095,7 @@ class TestOutputFormatting:
             debug=False,
             dry_run=False,
             quiet=False,  # NOT quiet
-            allow_bias=False,
+            scale_darks=False,
         )
 
         captured = capsys.readouterr()
@@ -1150,7 +1150,7 @@ class TestOutputFormatting:
             debug=False,
             dry_run=False,
             quiet=False,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         captured = capsys.readouterr()
@@ -1202,7 +1202,7 @@ class TestOutputFormatting:
             debug=False,
             dry_run=False,
             quiet=True,  # Quiet mode
-            allow_bias=False,
+            scale_darks=False,
         )
 
         captured = capsys.readouterr()
@@ -1260,7 +1260,7 @@ class TestEdgeCases:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         assert result["moved"] == 1
@@ -1313,7 +1313,7 @@ class TestEdgeCases:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         assert result["moved"] == 1
@@ -1374,7 +1374,7 @@ class TestCriticalEdgeCases:
 
         # This should complete without error
         result = move_lights_to_data.is_group_complete_and_self_contained(
-            str(tree), str(source), allow_bias=False, debug=False, quiet=True
+            str(tree), str(source), scale_darks=False, debug=False, quiet=True
         )
 
         # When no valid lights are found, directory is skipped
@@ -1403,7 +1403,7 @@ class TestCriticalEdgeCases:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # Should return empty results
@@ -1433,7 +1433,7 @@ class TestCriticalEdgeCases:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # Should return empty results after filtering
@@ -1491,7 +1491,7 @@ class TestCriticalEdgeCases:
             debug=False,
             dry_run=False,
             quiet=True,
-            allow_bias=False,
+            scale_darks=False,
         )
 
         # Should complete without error
@@ -1577,7 +1577,7 @@ class TestPrintSummary:
             "errors": 0,
         }
 
-        move_lights_to_data.print_summary(results, allow_bias=False)
+        move_lights_to_data.print_summary(results, scale_darks=False)
 
         captured = capsys.readouterr()
         assert "Summary" in captured.out
@@ -1587,7 +1587,7 @@ class TestPrintSummary:
         assert "Flats:" in captured.out
 
     def test_print_summary_with_bias(self, capsys):
-        """Prints summary with bias metrics when allow_bias=True."""
+        """Prints summary with bias metrics when scale_darks=True."""
         results = {
             "dir_count": 10,
             "target_count": 2,
@@ -1601,7 +1601,7 @@ class TestPrintSummary:
             "errors": 0,
         }
 
-        move_lights_to_data.print_summary(results, allow_bias=True)
+        move_lights_to_data.print_summary(results, scale_darks=True)
 
         captured = capsys.readouterr()
         assert "Biases: 1 of 3" in captured.out  # 3 needed - 2 missing = 1 present
@@ -1622,7 +1622,7 @@ class TestPrintSummary:
             "errors": 3,
         }
 
-        move_lights_to_data.print_summary(results, allow_bias=False)
+        move_lights_to_data.print_summary(results, scale_darks=False)
 
         captured = capsys.readouterr()
         assert "Errors: 3" in captured.out
@@ -1642,7 +1642,7 @@ class TestPrintSummary:
             "errors": 0,
         }
 
-        move_lights_to_data.print_summary(results, allow_bias=False)
+        move_lights_to_data.print_summary(results, scale_darks=False)
 
         captured = capsys.readouterr()
         assert "Darks:" in captured.out


### PR DESCRIPTION
- Rename CLI flag from --allow-bias to --scale-dark for consistency with singular convention
- Use BooleanOptionalAction for cleaner boolean flag handling
- Rename parameter from allow_bias to scale_darks throughout codebase
- Update help text to be more descriptive of functionality
- Update README and documentation to reflect new flag name

Assisted-by: Claude Code (Claude Sonnet 4.5)