### PR TITLE
Update CI workflows and pin mypy version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,9 @@ name: Lint
 
 on:
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
   push:
-    branches: [ main, master ]
+    branches: [ main ]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Test
 
 on:
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
   push:
-    branches: [ main, master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
     "pytest-mock>=3.0",
     "black>=23.0",
     "flake8>=6.0",
-    "mypy",
+    "mypy==1.11.2",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
This PR updates the CI/CD configuration and development dependencies to streamline the build process and ensure consistent type checking behavior.

## Key Changes
- **CI Workflows**: Updated both `lint.yml` and `test.yml` to only trigger on the `main` branch, removing the legacy `master` branch from the workflow triggers
- **Development Dependencies**: Pinned `mypy` to version `1.11.2` in `pyproject.toml` to ensure consistent type checking across all development environments

## Details
The removal of `master` branch from CI workflows reflects a shift to a single primary branch strategy. Pinning the mypy version prevents unexpected behavior changes from automatic dependency updates and ensures reproducible type checking results across different development setups.

https://claude.ai/code/session_012BrAXGCKqT6UGJrJRLAdr7